### PR TITLE
Fixes #76

### DIFF
--- a/packages/SwaLint-Preferences.package/.squot-contents
+++ b/packages/SwaLint-Preferences.package/.squot-contents
@@ -1,4 +1,5 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
+	#objectsReplacedByNames : true,
 	#serializer : #SquotCypressCodeSerializer
 }

--- a/packages/SwaLint-Preferences.package/SLPreference.class/instance/readableName.st
+++ b/packages/SwaLint-Preferences.package/SLPreference.class/instance/readableName.st
@@ -1,0 +1,13 @@
+menu
+readableName
+	"Split camel-case preferences into a readable string with spaces."
+	
+	| result |
+	result := (self name includes: Character space)
+		ifTrue: [self name asString copy]
+		ifFalse: [self name findFeatures joinSeparatedBy: ' '].
+	
+	"Ensure first letter is uppercase"
+	result at: 1 put: (result at: 1) asUppercase.
+	
+	^ result

--- a/packages/SwaLint-Preferences.package/SLPreference.class/methodProperties.json
+++ b/packages/SwaLint-Preferences.package/SLPreference.class/methodProperties.json
@@ -19,6 +19,7 @@
 		"preferenceValue:" : "AT 12/4/2007 14:04",
 		"printOn:" : "AT 12/4/2007 14:04",
 		"rawValue:" : "AT 12/4/2007 14:04",
+		"readableName" : "ct 1/28/2020 15:33",
 		"representativeButtonWithColor:inPanel:" : "AT 12/4/2007 14:04",
 		"restoreDefaultValue" : "SO 7/10/2014 11:34",
 		"selectors" : "BD 6/29/2018 13:06",


### PR DESCRIPTION
As `SLPreference` does *not* inherit from `Preference`, we need to copy the public interface. This does not feel very nice, but it has been usual for a long time, so let's fix it again. Complements the changes in [System-mt.1086](http://forum.world.st/The-Trunk-System-mt-1086-mcz-td5102456.html).

Please note at some time we should consider to wrap or inherit from Preference.